### PR TITLE
Revert to LTS version of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:14.04
 
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN pip install virtualenv
 
 RUN pip install virtualenvwrapper
 
+RUN apt-get -yq install libjpeg-dev zlib1g-dev
+
 RUN pip install Pillow
 
 RUN pip install Django==1.4.20


### PR DESCRIPTION
@bhaugen @fosterlynn 

I went the installation process again to figure the docker image build would fail without these modifications. Besides the following command fails also:

```
./manage.py syncdb --noinput
```

with this error message

```
django.db.utils.DatabaseError: no such table: django_content_type
```

Have you already encountered this issue when creating the database schema in development? 